### PR TITLE
fix: make header more responsive (mobile)

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,88 +1,19 @@
 <template>
-  <header class="flex items-center justify-between mb-6">
-    <div class="flex items-center gap-4">
-      <img
-        src="/images/nuxt.care-logo.svg"
-        alt="nuxt.care Logo"
-        class="h-12 w-12"
-      >
-      <div>
-        <h1 class="text-2xl font-bold text-neutral-900 dark:text-white flex items-center gap-2">
-          nuxt.care
-          <UBadge
-            color="primary"
-            variant="subtle"
-            size="xs"
-          >
-            v{{ version }}
-          </UBadge>
-        </h1>
-        <div class="flex items-center gap-3">
-          <NuxtLink
-            to="/docs"
-            class="inline-flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
-          >
-            <UIcon
-              name="i-lucide-book-open"
-              class="w-3 h-3"
-            />
-            Docs
-          </NuxtLink>
-          <span class="text-neutral-300 dark:text-neutral-600">|</span>
-          <a
-            href="https://github.com/Flo0806/nuxt.care"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
-          >
-            <UIcon
-              name="i-lucide-star"
-              class="w-3 h-3"
-            />
-            Star on GitHub
-            <UBadge
-              color="neutral"
-              variant="subtle"
-              size="xs"
-            >
-              {{ stars }}
-            </UBadge>
-          </a>
-        </div>
-      </div>
-    </div>
-    <div class="flex items-center gap-4">
-      <UTooltip
-        v-if="criticalCount > 0"
-        text="Click to show critical modules"
-      >
-        <button
-          class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
-          @click="$emit('show-critical')"
-        >
-          <UIcon
-            name="i-lucide-alert-triangle"
-            class="w-4 h-4"
-          />
-          {{ criticalCount }} Critical
-        </button>
-      </UTooltip>
-      <span
-        v-if="syncStatus?.lastSync"
-        class="text-xs text-neutral-600 dark:text-neutral-400"
-      >
-        Updated {{ formatTimeAgo(syncStatus.lastSync) }}
-      </span>
-      <UBadge
-        v-if="syncStatus?.isRunning"
-        color="warning"
-        variant="soft"
-      >
-        Syncing {{ syncStatus.syncedModules }}/{{ syncStatus.totalModules }}
-      </UBadge>
-      <AuthButton />
-      <UColorModeButton />
-    </div>
+  <header class="mb-6">
+    <AppHeaderMobile
+      :version="version"
+      :stars="stars"
+      :sync-status="syncStatus"
+      :critical-count="criticalCount"
+      @show-critical="$emit('show-critical')"
+    />
+    <AppHeaderDesktop
+      :version="version"
+      :stars="stars"
+      :sync-status="syncStatus"
+      :critical-count="criticalCount"
+      @show-critical="$emit('show-critical')"
+    />
   </header>
 </template>
 
@@ -108,19 +39,4 @@ const { data: repoData } = await useFetch<{ stargazers_count: number }>(
 )
 
 const stars = computed(() => repoData.value?.stargazers_count ?? 0)
-
-function formatTimeAgo(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = Date.now()
-  const diff = now - date.getTime()
-
-  const minutes = Math.floor(diff / 60000)
-  if (minutes < 60) return `${minutes}m ago`
-
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
 </script>

--- a/app/components/AppHeaderDesktop.vue
+++ b/app/components/AppHeaderDesktop.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="hidden sm:flex items-center justify-between">
+    <!-- Left: Logo + Title + Links -->
+    <div class="flex items-center gap-4">
+      <img
+        src="/images/nuxt.care-logo.svg"
+        alt="nuxt.care Logo"
+        class="h-12 w-12"
+      >
+      <div>
+        <h1 class="text-2xl font-bold text-neutral-900 dark:text-white flex items-center gap-2">
+          nuxt.care
+          <UBadge
+            color="primary"
+            variant="subtle"
+            size="xs"
+          >
+            v{{ version }}
+          </UBadge>
+        </h1>
+        <div class="flex items-center gap-3">
+          <NuxtLink
+            to="/docs"
+            class="inline-flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
+          >
+            <UIcon
+              name="i-lucide-book-open"
+              class="w-3 h-3"
+            />
+            Docs
+          </NuxtLink>
+          <span class="text-neutral-300 dark:text-neutral-600">|</span>
+          <a
+            href="https://github.com/Flo0806/nuxt.care"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
+          >
+            <UIcon
+              name="i-lucide-star"
+              class="w-3 h-3"
+            />
+            Star on GitHub
+            <UBadge
+              color="neutral"
+              variant="subtle"
+              size="xs"
+            >
+              {{ stars }}
+            </UBadge>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right: Actions -->
+    <div class="flex items-center gap-4">
+      <UTooltip
+        v-if="criticalCount > 0"
+        text="Click to show critical modules"
+      >
+        <button
+          class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
+          @click="$emit('show-critical')"
+        >
+          <UIcon
+            name="i-lucide-alert-triangle"
+            class="w-4 h-4"
+          />
+          {{ criticalCount }} Critical
+        </button>
+      </UTooltip>
+      <span
+        v-if="syncStatus?.lastSync"
+        class="text-xs text-neutral-600 dark:text-neutral-400"
+      >
+        Updated {{ formatTimeAgo(syncStatus.lastSync) }}
+      </span>
+      <UBadge
+        v-if="syncStatus?.isRunning"
+        color="warning"
+        variant="soft"
+      >
+        Syncing {{ syncStatus.syncedModules }}/{{ syncStatus.totalModules }}
+      </UBadge>
+      <AuthButton />
+      <UColorModeButton />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { SyncMeta } from '~~/shared/types/modules'
+
+defineProps<{
+  version: string
+  stars: number
+  syncStatus?: SyncMeta | null
+  criticalCount: number
+}>()
+
+defineEmits<{
+  'show-critical': []
+}>()
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - date.getTime()
+
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 60) return `${minutes}m ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+</script>

--- a/app/components/AppHeaderMobile.vue
+++ b/app/components/AppHeaderMobile.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="sm:hidden">
+    <!-- Top row: Logo + Title + Links | Version -->
+    <div class="flex items-start justify-between gap-2 mb-2">
+      <div class="flex items-center gap-3">
+        <img
+          src="/images/nuxt.care-logo.svg"
+          alt="nuxt.care Logo"
+          class="h-10 w-10"
+        >
+        <div class="flex items-center gap-2 flex-wrap">
+          <h1 class="text-xl font-bold text-neutral-900 dark:text-white">
+            nuxt.care
+          </h1>
+          <NuxtLink
+            to="/docs"
+            class="inline-flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
+          >
+            <UIcon
+              name="i-lucide-book-open"
+              class="w-3 h-3"
+            />
+            Docs
+          </NuxtLink>
+          <a
+            href="https://github.com/Flo0806/nuxt.care"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-400 hover:text-primary-500 transition-colors"
+          >
+            <UIcon
+              name="i-lucide-star"
+              class="w-3 h-3"
+            />
+            <UBadge
+              color="neutral"
+              variant="subtle"
+              size="xs"
+            >
+              {{ stars }}
+            </UBadge>
+          </a>
+        </div>
+      </div>
+      <UBadge
+        color="primary"
+        variant="subtle"
+        size="xs"
+        class="shrink-0"
+      >
+        v{{ version }}
+      </UBadge>
+    </div>
+
+    <!-- Actions row -->
+    <div class="flex items-center gap-2 flex-wrap">
+      <UTooltip
+        v-if="criticalCount > 0"
+        text="Click to show critical modules"
+      >
+        <button
+          class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
+          @click="$emit('show-critical')"
+        >
+          <UIcon
+            name="i-lucide-alert-triangle"
+            class="w-4 h-4"
+          />
+          {{ criticalCount }} Critical
+        </button>
+      </UTooltip>
+      <UBadge
+        v-if="syncStatus?.isRunning"
+        color="warning"
+        variant="soft"
+        size="xs"
+      >
+        Syncing {{ syncStatus.syncedModules }}/{{ syncStatus.totalModules }}
+      </UBadge>
+      <div class="flex-1" />
+      <AuthButton />
+      <UColorModeButton />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { SyncMeta } from '~~/shared/types/modules'
+
+defineProps<{
+  version: string
+  stars: number
+  syncStatus?: SyncMeta | null
+  criticalCount: number
+}>()
+
+defineEmits<{
+  'show-critical': []
+}>()
+</script>

--- a/app/components/AuthButton.vue
+++ b/app/components/AuthButton.vue
@@ -32,7 +32,7 @@ const items = [
     >
       <UAvatar
         :src="user?.avatarUrl"
-        :alt="user?.username"
+        alt="github avatar"
         size="xs"
       />
       <span class="ml-2 hidden sm:inline">{{ user?.username }}</span>


### PR DESCRIPTION
Closed: #2 

---

- [X] Separate mobile/desktop layouts into components                                                                                                                                                                                                                                                                                             
- [X] Mobile: Logo + title + links in one row, version badge top-right                                                                                                                                                                                                                                                                            
- [X] Mobile: Actions row with critical button, sync status, auth, color mode                                                                                                                                                                                                                                                                     
- [X] Desktop: Original single-row layout preserved                                                                                                                                                                                                                                                                                               
- [X] Fix a11y redundant alt text on avatar image  