### PR TITLE
feat: Add contributions filter for logged in users

### DIFF
--- a/app/components/modules/ModuleToolbar.vue
+++ b/app/components/modules/ModuleToolbar.vue
@@ -128,6 +128,28 @@
       </UButton>
 
       <UButton
+        v-if="isLoggedIn"
+        :color="showContributedOnly ? 'primary' : 'neutral'"
+        :variant="showContributedOnly ? 'soft' : 'ghost'"
+        size="sm"
+        @click="$emit('update:showContributedOnly', !showContributedOnly)"
+      >
+        <UIcon
+          name="i-lucide-user-round-check"
+          class="w-4 h-4"
+        />
+        Contributed
+        <UBadge
+          v-if="contributedCount"
+          color="primary"
+          variant="subtle"
+          size="xs"
+        >
+          {{ contributedCount }}
+        </UBadge>
+      </UButton>
+
+      <UButton
         v-if="hasActiveFilters"
         color="neutral"
         variant="ghost"
@@ -160,6 +182,7 @@ defineProps<{
   showFavoritesOnly: boolean
   showStarsOnly: boolean
   showCriticalOnly: boolean
+  showContributedOnly: boolean
   activeChips: Set<string>
   categoryOptions: Array<{ label: string, value: string, icon?: string }>
   typeOptions: Array<{ label: string, value: string }>
@@ -169,6 +192,7 @@ defineProps<{
   moduleCount: number
   favoritesCount: number
   starsCount: number
+  contributedCount: number
   criticalCount: number
   isLoggedIn: boolean
 }>()
@@ -182,6 +206,7 @@ defineEmits<{
   'update:filterMaintainer': [value: string]
   'update:showFavoritesOnly': [value: boolean]
   'update:showStarsOnly': [value: boolean]
+  'update:showContributedOnly': [value: boolean]
   'update:showCriticalOnly': [value: boolean]
   'toggle-chip': [chipId: string]
   'reset': []

--- a/app/composables/useModuleFilters.ts
+++ b/app/composables/useModuleFilters.ts
@@ -86,7 +86,7 @@ export function getCompatStatus(mod: ModuleData): 'nuxt4' | 'nuxt3' | 'unknown' 
   return 'unknown'
 }
 
-export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, favorites: Ref<string[]>, stars: Ref<string[]>) {
+export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, favorites: Ref<string[]>, stars: Ref<string[]>, user?: Ref<SessionUser | null>) {
   const search = ref('')
   const sortBy = ref('score')
 
@@ -105,6 +105,7 @@ export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, 
   const showFavoritesOnly = ref(false)
   const showStarsOnly = ref(false)
   const showCriticalOnly = ref(false)
+  const showContributedOnly = ref(false)
   const activeChips = ref<Set<string>>(new Set())
 
   // Helper: apply all filters, optionally excluding one (for dynamic dropdown options)
@@ -147,6 +148,12 @@ export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, 
 
     if (showStarsOnly.value) {
       result = result.filter(m => stars.value.includes(m.name))
+    }
+
+    if (showContributedOnly.value) {
+      const username = user?.value?.username
+      if (!username) return []
+      result = result.filter(m => m.contributors?.contributors?.includes(username))
     }
 
     if (activeChips.value.size > 0) {
@@ -223,6 +230,7 @@ export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, 
       || showFavoritesOnly.value
       || showStarsOnly.value
       || showCriticalOnly.value
+      || showContributedOnly.value
       || activeChips.value.size > 0
   })
 
@@ -246,6 +254,7 @@ export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, 
     showFavoritesOnly.value = false
     showStarsOnly.value = false
     showCriticalOnly.value = false
+    showContributedOnly.value = false
     activeChips.value = new Set()
   }
 
@@ -286,6 +295,7 @@ export function useModuleFilters(modules: Ref<ModuleData[] | null | undefined>, 
     filterMaintainer,
     showFavoritesOnly,
     showStarsOnly,
+    showContributedOnly,
     showCriticalOnly,
     activeChips,
     toggleChip,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,6 +29,7 @@
           v-model:filter-compat="filterCompat"
           v-model:filter-maintainer="filterMaintainer"
           v-model:show-favorites-only="showFavoritesOnly"
+          v-model:show-contributed-only="showContributedOnly"
           v-model:show-critical-only="showCriticalOnly"
           v-model:show-stars-only="showStarsOnly"
           :active-chips="activeChips"
@@ -40,6 +41,7 @@
           :module-count="filteredModules.length"
           :favorites-count="favorites.length"
           :stars-count="stars.length"
+          :contributed-count="contributedCount"
           :critical-count="criticalCount"
           :is-logged-in="isLoggedIn"
           @toggle-chip="toggleChip"
@@ -125,7 +127,7 @@ const { data: syncStatus, refresh: refreshSyncStatus } = await useFetch<SyncMeta
 })
 
 const { favorites, toggleFavorite } = useFavorites()
-const { isLoggedIn } = useAuth()
+const { isLoggedIn, user } = useAuth()
 const { loadAllStarred, initialized: starsInitialized, starredRepos } = useStars()
 
 const stars = computed(() => {
@@ -175,7 +177,14 @@ const {
   hasActiveFilters,
   resetFilters,
   filteredModules,
-} = useModuleFilters(modules, favorites, stars)
+  showContributedOnly,
+} = useModuleFilters(modules, favorites, stars, user)
+
+const contributedCount = computed(() => {
+  if (!modules.value || !user.value) return 0
+  const username = user.value.username
+  return modules.value.filter(m => m.contributors?.contributors?.includes(username)).length
+})
 
 // Pagination
 const itemsPerPage = 12
@@ -199,7 +208,7 @@ const paginationEnd = computed(() => {
 })
 
 // Reset page when filters change
-watch([search, sortBy, filterCategory, filterType, filterCompat, filterMaintainer, showFavoritesOnly, showStarsOnly, showCriticalOnly, activeChips], () => {
+watch([search, sortBy, filterCategory, filterType, filterCompat, filterMaintainer, showFavoritesOnly, showStarsOnly, showContributedOnly, showCriticalOnly, activeChips], () => {
   currentPage.value = 1
 })
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Changes

- New contribution filter that enables filtering and shows the amount of nuxt modules with own contributions on Github

## Related Issue

Closes #21 

## Checklist

- [x] Tested locally
- [x] No console errors
